### PR TITLE
Use six.StringIO for py2/py3 compatibility without unicode/str errors

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -18,7 +18,6 @@ import datetime
 from datetime import timedelta
 from dateutil.parser import parse
 from dateutil.tz import tzutc
-import io
 import itertools
 import time
 

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -560,7 +560,7 @@ class CredentialReport(Filter):
             return report
         data = self.fetch_credential_report()
         report = {}
-        reader = csv.reader(io.StringIO(data))
+        reader = csv.reader(six.StringIO(data))
         headers = reader.next()
         for line in reader:
             info = dict(zip(headers, line))


### PR DESCRIPTION
Upstream PR: https://github.com/capitalone/cloud-custodian/pull/1343